### PR TITLE
Highlight shell command tutorial two

### DIFF
--- a/_react/2-first-app.md
+++ b/_react/2-first-app.md
@@ -262,7 +262,7 @@ As soon as you've done that go to your API key page by going to <a target="_blan
 
 Now that we have access to all the weather data our heart could desire, let's get on with our app!
 
-Inside our `fetchData` function, we'll have to make a request to the API. I like to use a npm module called `xhr` for this, a wrapper around the JavaScript XMLHttpRequest that makes said requests a lot easier. Run 
+Inside our `fetchData` function, we'll have to make a request to the API. I like to use a npm module called `xhr` for this, a wrapper around the JavaScript XMLHttpRequest that makes said requests a lot easier. Run:
 
 ```Sh
 npm install --save xhr

--- a/_react/2-first-app.md
+++ b/_react/2-first-app.md
@@ -262,7 +262,13 @@ As soon as you've done that go to your API key page by going to <a target="_blan
 
 Now that we have access to all the weather data our heart could desire, let's get on with our app!
 
-Inside our `fetchData` function, we'll have to make a request to the API. I like to use a npm module called `xhr` for this, a wrapper around the JavaScript XMLHttpRequest that makes said requests a lot easier. Run `npm install --save xhr` to get it! While that's installing, `import` it in your App component at the top:
+Inside our `fetchData` function, we'll have to make a request to the API. I like to use a npm module called `xhr` for this, a wrapper around the JavaScript XMLHttpRequest that makes said requests a lot easier. Run 
+
+```Sh
+npm install --save xhr
+```
+
+to get it! While that's installing, `import` it in your App component at the top:
 
 ```JS
 // App.js


### PR DESCRIPTION
The command `npm install --save xhr` is not immediately visible when its in the middle of the text, which leads to an import error when we forget to run it.

I propose we give this command the same highlight as the previous shell commands (e.g. `npm install -g create-react-app` in the beginning of the page).