### PR TITLE
react-redux was missing in the dependencies

### DIFF
--- a/weather-app/package.json
+++ b/weather-app/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "react": "^15.2.1",
     "react-dom": "^15.2.1",
+    "react-redux": "^4.4.5",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",
     "xhr": "^2.2.2"


### PR DESCRIPTION
I guess it worth to be added in the gh-pages branch.
